### PR TITLE
changing the default ftp mode to passive?

### DIFF
--- a/lib/glynn/ftp.rb
+++ b/lib/glynn/ftp.rb
@@ -19,6 +19,7 @@ module Glynn
     private
     def connect
       Net::FTP.open(host) do |ftp|
+        ftp.passive = true
         ftp.connect(host, port)
         ftp.login(username, password)
         yield ftp


### PR DESCRIPTION
Nearly all ftp servers support passive mode, while users behind
restrictive firewalls still sometimes run into trouble with ft active
mode. I propose to make passive mode the default.
