### PR TITLE
FTPS support 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     glynn (1.1.0)
+      double-bag-ftps (~> 0.1.2)
       jekyll
 
 GEM
@@ -18,10 +19,11 @@ GEM
     coffee-script-source (1.8.0)
     colorator (0.1)
     diff-lcs (1.2.3)
+    double-bag-ftps (0.1.2)
     execjs (2.2.1)
     fakefs (0.5.3)
     fast-stemmer (1.0.2)
-    ffi (1.9.3)
+    ffi (1.9.5)
     hitimes (1.2.2)
     jekyll (2.4.0)
       classifier-reborn (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ For example, this is my _config.yml file :
     ftp_port: 21                  # default 21
     ftp_username: 'your_user'     # default read from stdin
     ftp_password: 'your_ftp_pass' # default read from stdin
+    ftp_secure: true              # default false (double-bag-ftps as dependencie needed)
 
 Glynn will connect itself to the host "dmathieu.com" and send every file to the FTP directory /web/portfolio.
 To do so, you just need to be at the top of your jekyll project. And in a console, enter the following :

--- a/bin/glynn
+++ b/bin/glynn
@@ -22,13 +22,14 @@ end
 options  = Jekyll.configuration(options)
 ftp_port = (options['ftp_port'] || 21).to_i
 passive  = options['ftp_passive'] || true
+ftp_secure  = options['ftp_secure'] || false
 
 puts "Building site: #{options['source']} -> #{options['destination']}"
 jekyll = Glynn::Jekyll.new
 jekyll.build
 puts "Successfully generated site"
 
-puts "Sending site over FTP (host: #{options['ftp_host']}, port: #{ftp_port})"
+puts "Sending site over FTP (host: #{options['ftp_host']}, port: #{ftp_port}, ftps: #{ftp_secure})"
 begin
   if options['ftp_username'].nil?
     print "FTP Username: "
@@ -53,7 +54,7 @@ rescue NoMethodError, Interrupt
   exit
 end
 
-ftp = Glynn::Ftp.new(options['ftp_host'], ftp_port, {:username => username, :password => password, :passive => passive})
+ftp = Glynn::Ftp.new(options['ftp_host'], ftp_port, {:username => username, :password => password, :passive => passive, :ftp_secure => ftp_secure})
 puts "\r\nConnected to server. Sending site"
 ftp.sync(options['destination'], options['ftp_dir'])
 puts "Successfully sent site"

--- a/glynn.gemspec
+++ b/glynn.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest"
 
   s.add_dependency('jekyll', [">= 0"])
+  s.add_dependency('double-bag-ftps', ["~> 0.1.2"])
 end

--- a/lib/glynn/ftp.rb
+++ b/lib/glynn/ftp.rb
@@ -20,22 +20,22 @@ module Glynn
 
     private
     def connect
-      if @ftp_secure == false
-        Net::FTP.open(host) do |ftp|
-          ftp.passive = @passive
-          ftp.connect(host, port)
-          ftp.login(username, password)
-          yield ftp
-        end
-      else
+      if @ftp_secure == true
         require 'double_bag_ftps'
-        
+
         DoubleBagFTPS.open(host,nil,nil,nil,DoubleBagFTPS::EXPLICIT) do |ftps|
           ftps.passive = @passive
           ftps.ssl_context = DoubleBagFTPS.create_ssl_context(:verify_mode => OpenSSL::SSL::VERIFY_NONE)
           ftps.connect(host, port)
           ftps.login(username, password)
           yield ftps
+        end
+      else
+        Net::FTP.open(host) do |ftp|
+          ftp.passive = @passive
+          ftp.connect(host, port)
+          ftp.login(username, password)
+          yield ftp
         end
       end
     end

--- a/lib/glynn/ftp.rb
+++ b/lib/glynn/ftp.rb
@@ -1,5 +1,4 @@
 require 'net/ftp'
-require 'double_bag_ftps'
 
 module Glynn
   class Ftp
@@ -29,6 +28,8 @@ module Glynn
           yield ftp
         end
       else
+        require 'double_bag_ftps'
+        
         DoubleBagFTPS.open(host,nil,nil,nil,DoubleBagFTPS::EXPLICIT) do |ftps|
           ftps.passive = @passive
           ftps.ssl_context = DoubleBagFTPS.create_ssl_context(:verify_mode => OpenSSL::SSL::VERIFY_NONE)

--- a/lib/glynn/ftp.rb
+++ b/lib/glynn/ftp.rb
@@ -1,14 +1,16 @@
 require 'net/ftp'
+require 'double_bag_ftps'
 
 module Glynn
   class Ftp
-    attr_reader :host, :port, :username, :password, :passive
+    attr_reader :host, :port, :username, :password, :passive, :ftp_secure
 
     def initialize(host, port = 21, options = Hash.new)
       options = {:username => nil, :password => nil}.merge(options)
       @host, @port = host, port
       @username, @password = options[:username], options[:password]
       @passive = options[:passive]
+      @ftp_secure = options[:ftp_secure]
     end
 
     def sync(local, distant)
@@ -19,11 +21,21 @@ module Glynn
 
     private
     def connect
-      Net::FTP.open(host) do |ftp|
-        ftp.passive = @passive
-        ftp.connect(host, port)
-        ftp.login(username, password)
-        yield ftp
+      if @ftp_secure == false
+        Net::FTP.open(host) do |ftp|
+          ftp.passive = @passive
+          ftp.connect(host, port)
+          ftp.login(username, password)
+          yield ftp
+        end
+      else
+        DoubleBagFTPS.open(host,nil,nil,nil,DoubleBagFTPS::EXPLICIT) do |ftps|
+          ftps.passive = @passive
+          ftps.ssl_context = DoubleBagFTPS.create_ssl_context(:verify_mode => OpenSSL::SSL::VERIFY_NONE)
+          ftps.connect(host, port)
+          ftps.login(username, password)
+          yield ftps
+        end
       end
     end
 


### PR DESCRIPTION
With the help of the double-bag-ftps dependencie I developed the option to use FTPS explicite.
You just have to add the "ftp_secure: true" option in your _config.yml.

If it's not set it defaults to false so nothing changes, in the default settings standard ftp works as usual.

I added this functionality because I didn't want to send my plain password over the internet.
Unfortunately I have never before coded something in Ruby so I hope there are no newbie errors.
Also I'm not sure how to develop the tests in Ruby and we should probably add double-bag-ftps dependencie as an dependencie to the project.

If someone gives me some hints I will glady try to do this stuff.

Other than that I'm using the ftps functionlity right now and didn't encounter any problems yet.