### PR TITLE
Allow credentials to be stored seperately

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Install it with gem install.
 
     gem install glynn --source http://gemcutter.org
 
-That's it ! You now have the Glynn executable on your machine.
+That's it! You now have the Glynn executable on your machine.
 Go to your jekyll project, configure the host and distant directory where the files will be sent.
-For example, this is my _config.yml file :
+For example, below is my **_config.yml** file. You can also store these options and FTP credentials in a file called **_glynn.yml** in the root of your project directory instead of **_config.yml** if you prefer. 
 
     markdown: rdiscount
     pygments: true

--- a/bin/glynn
+++ b/bin/glynn
@@ -24,6 +24,11 @@ options  = Jekyll.configuration(options)
 ftp_port = (options['ftp_port'] || 21).to_i
 passive  = options['ftp_passive'] || true
 
+# If _glynn.yml exists, load and merge these options
+if File.file?('_glynn.yml')
+  options = options.merge(YAML.load_file('_glynn.yml'))
+end
+
 puts "Building site: #{options['source']} -> #{options['destination']}"
 jekyll = Glynn::Jekyll.new
 jekyll.build


### PR DESCRIPTION
This pull request implements the functionality requested in issue #35. 

## The problem
I needed to store FTP login credentials in a place other than _config.yml - there was no good way to do this with the options provided by Jekyll. 

## The solution
With this pull request, Glynn will optionally read additional configuration values from _glynn.yml and merge them in with anything it finds in the regular Jekyll configuration.  This will allow FTP credentials for Glynn to be stored outside of the scope of the Jekyll project, if desired. 

If items are stored in both files, the values from _glynn.yml will be used. 