### PR TITLE
Include Username/Password from .netrc file if available

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     glynn (1.2.1)
       double-bag-ftps (~> 0.1.2)
+      highline (>= 1.5)
       jekyll
       netrc
 
@@ -14,6 +15,7 @@ GEM
     double-bag-ftps (0.1.2)
     fakefs (0.5.3)
     ffi (1.9.10)
+    highline (1.7.8)
     jekyll (3.0.0)
       colorator (~> 0.1)
       jekyll-sass-converter (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     glynn (1.2.1)
       double-bag-ftps (~> 0.1.2)
       jekyll
+      netrc
 
 GEM
   remote: https://rubygems.org/
@@ -36,6 +37,7 @@ GEM
     minitest (4.7.1)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
+    netrc (0.11.0)
     rake (10.0.4)
     rb-fsevent (0.9.6)
     rb-inotify (0.9.5)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ To do so, you just need to be at the top of your jekyll project. And in a consol
 
 Quite simple again. It'll connect to the remote host, ask you for login and password and send the files :)
 
+You can avoid keeping your login and password in your site configuration by saving it in your [`~/.netrc` file](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html); Glynn will even offer to save it there for you after the first time you enter it!
+
 Contributing
 ------------
 

--- a/bin/glynn
+++ b/bin/glynn
@@ -7,6 +7,7 @@ require 'highline'
 require 'io/console'
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
+netrc = Netrc.read
 cli = HighLine.new
 
 options = {}
@@ -34,7 +35,7 @@ if File.file?('_glynn.yml')
 end
 
 # Include Username/Password from .netrc file if available
-if netrc = Netrc.read[options['ftp_host']]
+if n = netrc[options['ftp_host']]
   if options['ftp_username'] || options['ftp_password']
     cli.say cli.color(
       "The username and password settings from the configuration file" +
@@ -42,7 +43,7 @@ if netrc = Netrc.read[options['ftp_host']]
       :yellow
     )
   end
-  options = (Hash[['ftp_username', 'ftp_password'].zip netrc]).merge options
+  options = (Hash[['ftp_username', 'ftp_password'].zip n]).merge options
 end
 
 puts "Building site: #{options['source']} -> #{options['destination']}"
@@ -63,6 +64,10 @@ begin
     print "FTP Password: "
     # Get the password without echoing characters
     password = $stdin.noecho(&:gets).chomp
+    if cli.agree("Would you like to save this password to #{Netrc.default_path}?")
+      netrc[options['ftp_host']] = username, password
+      netrc.save
+    end
   else
     password = options['ftp_password']
   end

--- a/bin/glynn
+++ b/bin/glynn
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require 'rubygems'
 require 'jekyll'
+require 'netrc'
 require 'glynn'
 require 'io/console'
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
@@ -28,6 +29,11 @@ ftp_secure = options['ftp_secure'] || false
 # If _glynn.yml exists, load and merge these options
 if File.file?('_glynn.yml')
   options = options.merge(YAML.load_file('_glynn.yml'))
+end
+
+# Include Username/Password from .netrc file if available
+if netrc = Netrc.read[options['ftp_host']]
+  options = options.merge(Hash[["ftp_username", "ftp_password"].zip netrc])
 end
 
 puts "Building site: #{options['source']} -> #{options['destination']}"

--- a/bin/glynn
+++ b/bin/glynn
@@ -3,9 +3,11 @@ require 'rubygems'
 require 'jekyll'
 require 'netrc'
 require 'glynn'
+require 'highline'
 require 'io/console'
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
+cli = HighLine.new
 
 options = {}
 case ARGV.size
@@ -33,6 +35,13 @@ end
 
 # Include Username/Password from .netrc file if available
 if netrc = Netrc.read[options['ftp_host']]
+  if options['ftp_username'] || options['ftp_password']
+    cli.say cli.color(
+      "The username and password settings from the configuration file" +
+      " take precedence over those in the netrc file!",
+      :yellow
+    )
+  end
   options = (Hash[['ftp_username', 'ftp_password'].zip netrc]).merge options
 end
 

--- a/bin/glynn
+++ b/bin/glynn
@@ -33,7 +33,7 @@ end
 
 # Include Username/Password from .netrc file if available
 if netrc = Netrc.read[options['ftp_host']]
-  options = options.merge(Hash[["ftp_username", "ftp_password"].zip netrc])
+  options = (Hash[['ftp_username', 'ftp_password'].zip netrc]).merge options
 end
 
 puts "Building site: #{options['source']} -> #{options['destination']}"

--- a/glynn.gemspec
+++ b/glynn.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_dependency('jekyll', [">= 0"])
   s.add_dependency('double-bag-ftps', ["~> 0.1.2"])
   s.add_dependency('netrc', [">= 0"])
+  s.add_dependency('highline', [">= 1.5"])
 end

--- a/glynn.gemspec
+++ b/glynn.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency('jekyll', [">= 0"])
   s.add_dependency('double-bag-ftps', ["~> 0.1.2"])
+  s.add_dependency('netrc', [">= 0"])
 end


### PR DESCRIPTION
After the conf files are read, this uses the host name to look up a
Username and Password in the user's ~/.netrc file.  The results are
mapped to the keys glynn expects and merged into the options.  This
allows users to specify passwords for their sites in .netrc instead of
in the code base where they might accidentally be publicised.

Although it may be useful to mention this in the README, I wasn't sure
it was noteworthy enough.  I didn't write any tests for it because it
seems the tests are rather unit tests for the support libraries, not for
the main program itself.

Things that I could add (possibly still within the scope of this PR):

 * Allow the user to specify a netrc somewhere other than the default
   location, using a setting in the config files
 * When the user is prompted to enter a password, offer to save it to
   their netrc so they don't have to type it again

Requires the netrc gem.  Fixes #48.