### PR TITLE
Add capability to configure environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,33 @@ To do so, you just need to be at the top of your jekyll project. And in a consol
 
     glynn
 
+You can also setup different environments into you **_glynn.yml** and can keep common configuration for both. For example:
+
+    markdown: rdiscount
+    pygments: true
+    auto: true
+    
+    # optional
+    ftp_port: 21                  # default 21
+    ftp_username: 'your_user'     # default read from stdin
+    ftp_password: 'your_ftp_pass' # default read from stdin
+    ftp_secure: true              # default false
+    ftp_passive: false
+    
+    production:
+        ftp_host: 'ricardovsilva.com'
+        ftp_dir: '/web/site/root'
+        
+    test:
+        ftp_host: 'test.ricardovsilva.com'
+        ftp_dir: '/web/site/root/test'
+
+
+Then just call glynn with -environment (or -e) parameter:
+    
+    glynn -e production
+    
+    
 Quite simple again. It'll connect to the remote host, ask you for login and password and send the files :)
 
 You can avoid keeping your login and password in your site configuration by saving it in your [`~/.netrc` file](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html); Glynn will even offer to save it there for you after the first time you enter it!

--- a/bin/glynn
+++ b/bin/glynn
@@ -70,7 +70,7 @@ jekyll = Glynn::Jekyll.new
 jekyll.build
 cli.say cli.color("Successfully generated site", :green)
 
-cli.say "Sending site over FTP (host: #{get_from_environment(environment, options, 'ftp_host')}, port: #{get_from_environment(environment, options, 'ftp_port')}, ftps: #{get_from_environment(environment, options, 'ftp_secure')})"
+cli.say "Sending site over FTP (host: #{get_from_environment(environment, options, 'ftp_host')}, port: #{ftp_port}, ftps: #{ftp_secure})"
 
 if get_from_environment(environment, options, 'ftp_username').nil?
   username = cli.ask "FTP Username: "

--- a/bin/glynn
+++ b/bin/glynn
@@ -11,6 +11,16 @@ netrc = Netrc.read
 cli = HighLine.new
 
 options = {}
+environment = ''
+
+if(ARGV.include? '-e' or ARGV.include? '-environment')
+  environment_index = (ARGV.index('-e') || ARGV.index('-environment'))
+  ARGV.delete_at(environment_index)
+  environment = ARGV[environment_index]
+  ARGV.delete_at(environment_index)
+end
+
+
 case ARGV.size
   when 0
   when 1
@@ -30,13 +40,13 @@ if File.file?('_glynn.yml')
   options = options.merge(YAML.load_file('_glynn.yml'))
 end
 
-ftp_port   = (options['ftp_port'] || 21).to_i
-passive    = options['ftp_passive'] || true
-ftp_secure = options['ftp_secure'] || false
+ftp_port   = (get_from_environment(environment, options, 'ftp_port') || 21).to_i
+passive    = get_from_environment(environment, options, 'ftp_passive') || true
+ftp_secure = get_from_environment(environment, options, 'ftp_secure') || false
 
 # Include Username/Password from .netrc file if available
-if n = netrc[options['ftp_host']]
-  if options['ftp_username'] || options['ftp_password']
+if n = netrc[ get_from_environment(environment, options, 'ftp_host') ]
+  if get_from_environment(environment, options, 'ftp_username') || get_from_environment(environment, options, 'ftp_password')
     cli.say cli.color(
       "The username and password settings from the configuration file" +
       " take precedence over those in the netrc file!",
@@ -51,31 +61,40 @@ jekyll = Glynn::Jekyll.new
 jekyll.build
 cli.say cli.color("Successfully generated site", :green)
 
-cli.say "Sending site over FTP (host: #{options['ftp_host']}, port: #{ftp_port}, ftps: #{ftp_secure})"
+cli.say "Sending site over FTP (host: #{options[environment]&['ftp_host'] || options['ftp_host']}, port: #{ftp_port}, ftps: #{ftp_secure})"
 
-if options['ftp_username'].nil?
+if get_from_environment(environment, options, 'ftp_username').nil?
   username = cli.ask "FTP Username: "
 else
-  username = options['ftp_username']
+  username = get_from_environment(environment, options, 'ftp_username')
 end
 
-if options['ftp_password'].nil?
+if get_from_environment(environment, options, 'ftp_password').nil?
   # Get the password without echoing characters
   password = cli.ask("FTP Password: ") { |q| q.echo = false }
   if cli.agree("Would you like to save this password to #{Netrc.default_path}?")
-    netrc[options['ftp_host']] = username, password
+    netrc[get_from_environment(environment, options, 'ftp_host')] = username, password
     netrc.save
   end
 else
-  password = options['ftp_password']
+  password = get_from_environment(environment, options, 'ftp_password')
 end
 
-ftp = Glynn::Ftp.new(options['ftp_host'], ftp_port, {
+ftp = Glynn::Ftp.new(get_from_environment(environment, options, 'ftp_host'), ftp_port, {
   :username => username,
   :password => password,
   :passive  => passive,
   :secure   => ftp_secure
 })
 cli.say "Connected to server. Sending site"
-ftp.sync(options['destination'], options['ftp_dir'])
+ftp.sync(get_from_environment(environment, options, 'destination'), get_from_environment(environment, options, 'ftp_dir'))
 cli.say cli.color("Successfully sent site", :green)
+
+
+def get_from_environment (environment, options, key)
+  if options[environment] and options[environment][key]
+    return options[environment][key]
+  else
+    return options[key]
+  end
+end 

--- a/bin/glynn
+++ b/bin/glynn
@@ -70,7 +70,7 @@ jekyll = Glynn::Jekyll.new
 jekyll.build
 cli.say cli.color("Successfully generated site", :green)
 
-cli.say "Sending site over FTP (host: #{options[environment]&['ftp_host'] || options['ftp_host']}, port: #{ftp_port}, ftps: #{ftp_secure})"
+cli.say "Sending site over FTP (host: #{get_from_environment(environment, options, 'ftp_host')}, port: #{get_from_environment(environment, options, 'ftp_port')}, ftps: #{get_from_environment(environment, options, 'ftp_secure')})"
 
 if get_from_environment(environment, options, 'ftp_username').nil?
   username = cli.ask "FTP Username: "

--- a/bin/glynn
+++ b/bin/glynn
@@ -7,6 +7,15 @@ require 'highline'
 require 'io/console'
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
+
+def get_from_environment (environment, options, key)
+  if options[environment] and options[environment][key]
+    return options[environment][key]
+  else
+    return options[key]
+  end
+end 
+
 netrc = Netrc.read
 cli = HighLine.new
 
@@ -89,12 +98,3 @@ ftp = Glynn::Ftp.new(get_from_environment(environment, options, 'ftp_host'), ftp
 cli.say "Connected to server. Sending site"
 ftp.sync(get_from_environment(environment, options, 'destination'), get_from_environment(environment, options, 'ftp_dir'))
 cli.say cli.color("Successfully sent site", :green)
-
-
-def get_from_environment (environment, options, key)
-  if options[environment] and options[environment][key]
-    return options[environment][key]
-  else
-    return options[key]
-  end
-end 

--- a/lib/glynn/version.rb
+++ b/lib/glynn/version.rb
@@ -1,3 +1,3 @@
 module Glynn
-  VERSION = '1.2.3'
+  VERSION = '1.2.5'
 end


### PR DESCRIPTION
I had the need to upload one of my projects to two distincts environment. I was using branches with different config inside _glynn.yml, but often I merge these branch and lost all configs.
So I decided to add the capability to choose environment at command line, with these modifications you can select what environment but that is not required. That way, who already uses glynn will still can use without any change.
More details on README.md